### PR TITLE
added point prompt to SAM2 model

### DIFF
--- a/autodistill_grounded_sam_2/grounded_sam_2.py
+++ b/autodistill_grounded_sam_2/grounded_sam_2.py
@@ -42,7 +42,16 @@ class GroundedSAM2(DetectionBaseModel):
         self.grounding_dino_box_threshold = grounding_dino_box_threshold
         self.grounding_dino_text_threshold = grounding_dino_text_threshold
 
-    def predict(self, input: Any) -> sv.Detections:
+    def predict(self, input: Any, points: list = None, point_labels: list = None) -> sv.Detections:
+        """
+        Run prediction on an image. Optionally, segment using point prompts.
+        Args:
+            input: Image path or array.
+            points: Optional[List[List[float]]], list of [x, y] points for point prompt.
+            point_labels: Optional[List[int]], 1 for foreground, 0 for background for each point.
+        Returns:
+            sv.Detections with masks.
+        """
         image = load_image(input, return_format="cv2")
 
         if self.model == "Florence 2":
@@ -69,13 +78,26 @@ class GroundedSAM2(DetectionBaseModel):
         with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
             self.sam_2_predictor.set_image(image)
             result_masks = []
-            for box in detections.xyxy:
+            if points is not None and point_labels is not None:
+                # Use point prompt for segmentation
                 masks, scores, _ = self.sam_2_predictor.predict(
-                    box=box, multimask_output=False
+                    point_coords=np.array(points),
+                    point_labels=np.array(point_labels),
+                    multimask_output=False
                 )
                 index = np.argmax(scores)
                 masks = masks.astype(bool)
                 result_masks.append(masks[index])
+                # For point prompt, detections may not have boxes, so create a dummy box
+                detections.xyxy = np.array([[0, 0, image.shape[1], image.shape[0]]])
+            else:
+                for box in detections.xyxy:
+                    masks, scores, _ = self.sam_2_predictor.predict(
+                        box=box, multimask_output=False
+                    )
+                    index = np.argmax(scores)
+                    masks = masks.astype(bool)
+                    result_masks.append(masks[index])
 
         detections.mask = np.array(result_masks)
 


### PR DESCRIPTION
This pull request introduces enhancements to the `predict` method in the `autodistill_grounded_sam_2.py` file, adding support for point-based prompts during segmentation. The changes also include updates to handle cases where bounding boxes are unavailable when using point prompts.

### Enhancements to the `predict` method:

* **Added support for point-based prompts**: The `predict` method now accepts `points` (a list of `[x, y]` coordinates) and `point_labels` (foreground/background labels) as optional arguments to enable segmentation using point prompts.
* **Implemented point-based segmentation logic**: When `points` and `point_labels` are provided, the method uses them to generate masks. If bounding boxes are unavailable, a dummy box covering the entire image is created.

Related issue: [autodistill#188](https://github.com/autodistill/autodistill/issues/188)